### PR TITLE
Add timeout and redirect configuration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,8 @@ use codec::deserialize;
 use codec::http::{Request, OP_PERFORM_REQUEST};
 use std::collections::HashMap;
 use std::error::Error;
-use std::sync::Arc;
-use std::sync::RwLock;
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
 
 const CAPABILITY_ID: &str = "wascc:http_client";
 const SYSTEM_ACTOR: &str = "system";
@@ -42,11 +42,29 @@ impl HttpClientProvider {
     /// Each actor gets a dedicated client so that we can take advantage of connection pooling.
     /// TODO: This needs to set things like timeouts, redirects, etc.
     fn configure(&self, config: CapabilityConfiguration) -> Result<Vec<u8>, Box<dyn Error>> {
-        // TODO read in config and set defaults
-        self.clients
-            .write()
-            .unwrap()
-            .insert(config.module.clone(), reqwest::Client::new());
+        let timeout = match config.values.get("timeout") {
+            Some(v) => {
+                let parsed: u64 = v.parse()?;
+                Duration::new(parsed, 0)
+            }
+            None => Duration::new(30, 0),
+        };
+
+        let redirect_policy = match config.values.get("max_redirects") {
+            Some(v) => {
+                let parsed: usize = v.parse()?;
+                reqwest::redirect::Policy::limited(parsed)
+            }
+            None => reqwest::redirect::Policy::default(),
+        };
+
+        self.clients.write().unwrap().insert(
+            config.module.clone(),
+            reqwest::Client::builder()
+                .timeout(timeout)
+                .redirect(redirect_policy)
+                .build()?,
+        );
         Ok(vec![])
     }
 


### PR DESCRIPTION
This adds two values actors can use to configure an http client:
* timeout: the duration to wait before timing out the request
* max_redirects: the maximum number of redirects to follow

The defaults are 30s and 10 redirects respectively.

Closes #2.